### PR TITLE
[WIP]: Added Mann-Whitney U test to differential expression plot

### DIFF
--- a/common.py
+++ b/common.py
@@ -61,6 +61,99 @@ def diff_exp(counts, group1, group2):
     return df
 
 
+def rankdata(a):
+    arr = np.asarray(a)
+
+    # argsort each column
+    sorter = np.argsort(arr, 0)
+
+    ix = sorter.ravel('F')
+    iy = np.repeat(np.arange(arr.shape[1]), arr.shape[0])
+
+    inv = np.empty(arr.shape, dtype=np.intp)
+    inv[ix,iy] = np.tile(np.arange(arr.shape[0], dtype=np.intp), arr.shape[1])
+
+    arr = arr[ix, iy].reshape(arr.shape, order='F')
+
+    obs = np.r_['0',
+                np.ones((1, arr.shape[1]), dtype=bool),
+                arr[1:,:] != arr[:-1,:],
+                np.ones((1, arr.shape[1]), dtype=bool)]
+
+    nzx, nzy = np.nonzero(obs.T)
+
+    xv,xc = np.unique(nzx, return_counts=True)
+    dense = obs.cumsum(axis=0)[inv.ravel('F'), iy] + np.r_[0, xc[:-1].cumsum()].repeat(arr.shape[0])
+
+    return 0.5 * (nzy[dense] + nzy[dense - 1] + 1).reshape(arr.shape, order='F')
+
+
+def tiecorrect(rankvals):
+    arr = np.sort(rankvals, axis=0)
+    size = np.float64(arr.shape[0])
+    if size < 2:
+        return 1.0
+
+    obs = np.r_['0',
+                np.ones((1, arr.shape[1]), dtype=bool),
+                arr[1:, :] != arr[:-1, :],
+                np.ones((1, arr.shape[1]), dtype=bool)]
+
+    nzx, nzy = np.nonzero(obs.T)
+
+    c = np.clip(np.diff(nzy), 0, None)
+    c2 = c ** 3 - c
+
+    return 1.0 - np.array(
+        list(map(np.sum, np.split(c2, np.where(c == 0)[0])))) / (
+                 size ** 3 - size)
+
+
+def mannwhitneyu(x, y, use_continuity=True):
+    """Version of Mann-Whitney U-test that handles arrays.
+
+    Only does two-sided tests at the moment. Which I'm not convinced is
+    implemented properly in scipy...need to check the math.
+    """
+    x = np.asarray(x)
+    y = np.asarray(y)
+    assert x.shape[1] == y.shape[1]
+
+    n1 = x.shape[0]
+    n2 = y.shape[0]
+
+    ranked = rankdata(np.concatenate((x, y)))
+    rankx = ranked[0:n1, :]  # get the x-ranks
+    u1 = n1 * n2 + (n1 * (n1 + 1)) / 2.0 - np.sum(rankx,
+                                                  axis=0)  # calc U for x
+    u2 = n1 * n2 - u1  # remainder is U for y
+    T = tiecorrect(ranked)
+
+    # if *everything* is identical we'll raise an error, not otherwise
+    if np.all(T == 0):
+        raise ValueError('All numbers are identical in mannwhitneyu')
+    sd = np.sqrt(T * n1 * n2 * (n1 + n2 + 1) / 12.0)
+
+    meanrank = n1 * n2 / 2.0 + 0.5 * use_continuity
+    bigu = np.max(np.vstack([u1, u2]), 0)
+
+    z = np.zeros_like(T)
+    z[T != 0] = (bigu - meanrank)[T != 0] / sd[T != 0]
+
+    p = 2 * stats.distributions.norm.sf(abs(z))
+
+    u = u2
+    return u, p
+
+
+def mannwhitney_diff_exp(counts, group1, group2):
+    u, p = mannwhitneyu(counts.loc[group1].as_matrix(),
+                        counts.loc[group2].as_matrix())
+
+    return pd.DataFrame({'u': u, 'p': p}, columns=['u', 'p'],
+                        index=counts.columns)
+
+
 class Plates(object):
 
     # Names of commonly accessed columns


### PR DESCRIPTION
I know that it's Saturday, but I was working anyway.

It would be good to use statistics and plots that don't assume unimodal normally distributed data, because we don't have that. This branch implements the Mann-Whitney U test for differential expression, which I managed to get running only 2-3x slower than the t-test we currently have (major addition to `common.py` that could possibly be refactored out or even sent to scipy as a PR). I added the U test as an option in the GUI.

This is a **work in progress** and should not be merged willy-nilly by math cowboys. A couple things remain:

- [ ] rather than bar plots, we should be showing violin plots or something else that displays the shape of the distribution. dash doesn't have this built in but it appears possible to add.
- [ ] the Mann-Whitney test works but it isn't returning directionality, which is obviously desirable. I think that adding that in is relatively simple but I haven't done it yet because Saturday.
